### PR TITLE
Enable blob tx pool for Nethermind

### DIFF
--- a/ansible/inventories/devnet-10/group_vars/nethermind.yaml
+++ b/ansible/inventories/devnet-10/group_vars/nethermind.yaml
@@ -39,6 +39,8 @@ nethermind_container_command_extra_args:
   - --EthStats.Secret={{ ethstats_secret }}
   - --EthStats.Server=wss://{{ ethstats_url }}/api/
   - --log={{ log_level | upper | default('DEBUG') }}
+  - --TxPool.BlobSupportEnabled=true
+  - --TxPool.PersistentBlobStorageEnabled=true
   #- --Init.KzgSetupPath /pth/to/kzg_trusted_setup.txt
 nethermind_container_pull: true
 

--- a/ansible/inventories/devnet-10/group_vars/nethermind.yaml
+++ b/ansible/inventories/devnet-10/group_vars/nethermind.yaml
@@ -41,6 +41,7 @@ nethermind_container_command_extra_args:
   - --log={{ log_level | upper | default('DEBUG') }}
   - --TxPool.BlobSupportEnabled=true
   - --TxPool.PersistentBlobStorageEnabled=true
+  - --TxPool.ReportMinutes=5
   #- --Init.KzgSetupPath /pth/to/kzg_trusted_setup.txt
 nethermind_container_pull: true
 

--- a/ansible/inventories/devnet-9/group_vars/blobber.yaml
+++ b/ansible/inventories/devnet-9/group_vars/blobber.yaml
@@ -2,7 +2,7 @@ blobber_container_image: "{{ default_tooling_images.blobber }}"
 
 blobber_log_level: trace
 
-ethereum_node_blobber_enabled: false
+ethereum_node_blobber_enabled: true
 
 # Storage configs
 blobber_datadir: /data/blobber

--- a/ansible/inventories/devnet-9/group_vars/nethermind.yaml
+++ b/ansible/inventories/devnet-9/group_vars/nethermind.yaml
@@ -39,6 +39,9 @@ nethermind_container_command_extra_args:
   - --EthStats.Secret={{ ethstats_secret }}
   - --EthStats.Server=wss://{{ ethstats_url }}/api/
   - --log={{ log_level | upper | default('DEBUG') }}
+  - --TxPool.BlobSupportEnabled=true
+  - --TxPool.PersistentBlobStorageEnabled=true
+  - --TxPool.ReportMinutes=5
   #- --Init.KzgSetupPath /pth/to/kzg_trusted_setup.txt
 nethermind_container_pull: true
 


### PR DESCRIPTION
The following options are disabled by default, so the PR is about to enable them for devnet-10:
- BlobSupportEnabled - handle blob txs
- PersistentBlobStorageEnabled - store them to allow huge tx pool